### PR TITLE
Add debug module with measure decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ Inspired by of Elixir's `get_in`. If you squint.
 For "soft" getting a value, use `get_in(collection, path)` where path is a list of keys/indices. This function optionally takes a `default` value to be returned if the final key/index is not found. By default this is `None`.
 
 For "hard" getting a value, use `require_in(collection, path)` where path is a list of keys/indices. This function raises a `NestedValueNotFoundError` if the final key/index is not found.
+
+## Debug
+
+`measure` is a function that given a log function, e.g. `logger.debug` returns a decorator that can be used to measure and log the execution time of another function.
+
+### Usage
+
+Create a measure decorator by calling `measure` with a logging function, e.g. `measure(logger.debug)`. By default this will be `logger.debug`.
+
+## Development
+
+To run the tests, ensure that you have installed [pytest-describe](https://pypi.org/project/pytest-describe) and run `pytest`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ license_files = LICENSE.md
 universal = 0
 
 [flake8]
-max-line-length = 88
+max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,17 @@
-from setuptools import setup, find_packages
 from os import path
+from setuptools import find_packages, setup
 
-here = path.abspath(path.dirname(__file__))
+HERE = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, "README.md"), encoding="utf-8") as f:
-    readme = f.read()
+with open(path.join(HERE, "README.md"), encoding="utf-8") as f:
+    README = f.read()
 
 
 setup(
     name="ormgrop",
-    version="0.1.0",
+    version="0.2.0",
     description="DevL's own standard library for Python 3",
-    long_description=readme,
+    long_description=README,
     long_description_content_type="text/markdown",
     url="https://devl.github.io/ormgrop",
     author="Lennart Fridén",

--- a/src/ormgrop/debug.py
+++ b/src/ormgrop/debug.py
@@ -1,0 +1,22 @@
+import functools
+import logging
+from time import perf_counter_ns as take_time
+
+logger = logging.getLogger(__name__)
+
+
+def measure(log_func=logger.debug):
+    def decorate(func):
+        @functools.wraps(func)
+        def measure_and_log(*args, **kwargs):
+            name = func.__name__
+            start = take_time()
+            result = func(*args, **kwargs)
+            finish = take_time()
+            elapsed_time = finish - start
+            log_func(f"[MEASURE] Called '{name}' for {elapsed_time} nanoseconds.")
+            return result
+
+        return measure_and_log
+
+    return decorate

--- a/tests/collections_test.py
+++ b/tests/collections_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from src.ormgrop.collections import get_in, require_in, NestedValueNotFoundError
 
 

--- a/tests/debug_test.py
+++ b/tests/debug_test.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+from src.ormgrop.debug import measure
+
+
+def describe_measure():
+    def _simple_function(arg_1, arg_2, kwarg_1=None, kwarg_2=None):
+        return {"arg_1": arg_1, "arg_2": arg_2, "kwarg_1": kwarg_1, "kwarg_2": kwarg_2}
+
+    def test_logging_mesurements():
+        logger = FakeLogger()
+        with patch("src.ormgrop.debug.take_time", side_effect=[179246391423, 179246392065]):
+            measured = measure(logger.log)(_simple_function)
+            result = measured(1, 2, kwarg_1=3, kwarg_2=4)
+
+            assert result == {"arg_1": 1, "arg_2": 2, "kwarg_1": 3, "kwarg_2": 4}
+            assert logger.messages == ["[MEASURE] Called '_simple_function' for 642 nanoseconds."]
+
+
+class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
+    def log(self, message):
+        self.messages.append(message)


### PR DESCRIPTION
`measure` is a function that given a log function, e.g. `logger.debug` returns a decorator that can be used to measure and log the execution time of another function.